### PR TITLE
fix crash on open_target_app

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -198,7 +198,7 @@ def create_dir(path):
 def open_target_app(isbundleid, value):
 	global session;
 	device = get_usb_iphone();
-	name = u'SpringBoard';
+	name = u'邮件';
 	print "open target app......"
 	session = device.attach(name);
 	script = load_js_file(session, APP_JS);


### PR DESCRIPTION
The crash happen on iPod Touch 5, 9.3.5.
change attach ’SpringBroad’ to ‘邮件’.
