### PR TITLE
Module initialisation check

### DIFF
--- a/dump.js
+++ b/dump.js
@@ -193,6 +193,7 @@ function dumpModule(name) {
     if (modules == null) {
         modules = getAllAppModules();
     }
+
     var targetmod = null;
     for (var i = 0; i < modules.length; i++) {
         if (modules[i].path.indexOf(name) != -1) {
@@ -207,7 +208,8 @@ function dumpModule(name) {
     var modbase = modules[i].base;
     var modsize = modules[i].size;
     var newmodname = modules[i].name;
-    var newmodpath = getDocumentDir() + "/" + newmodname;
+    Module.ensureInitialized(newmodname);
+    var newmodpath = getDocumentDir() + "/" + newmodname + ".fid";
     var oldmodpath = modules[i].path;
 
 

--- a/dump.py
+++ b/dump.py
@@ -300,7 +300,9 @@ if __name__ == '__main__':
                 output_ipa = display_name
             output_ipa = re.sub('\.ipa$', '', output_ipa)
             start_dump(device, pid, output_ipa)
-
+        except paramiko.ssh_exception.NoValidConnectionsError as e:
+            print e
+            exit_code = 1
         except paramiko.AuthenticationException as e:
             print e
             exit_code = 1

--- a/dump.py
+++ b/dump.py
@@ -240,7 +240,6 @@ def create_dir(path):
 def open_target_app(device, name_or_bundleid):
     print 'Start the target app {}'.format(name_or_bundleid)
 
-    pid = -1
     display_name = ''
     bundle_identifier = ''
     for application in get_applications(device):

--- a/dump.py
+++ b/dump.py
@@ -250,18 +250,17 @@ def open_target_app(device, name_or_bundleid):
 
     try:
         pid = device.spawn([bundle_identifier])
+        session = device.attach(pid)
         device.resume(pid)
-        time.sleep(1)
     except Exception as e:
         print e
 
-    return pid, display_name, bundle_identifier
+    return session, display_name, bundle_identifier
 
 
-def start_dump(device, pid, ipa_name):
+def start_dump(session, ipa_name):
     print 'Dumping {} to {}'.format(display_name, TEMP_DIR)
 
-    session = device.attach(pid)
     script = load_js_file(session, DUMP_JS)
     script.post('dump')
     finished.wait()
@@ -295,11 +294,11 @@ if __name__ == '__main__':
             ssh.connect(Host, port=Port, username=User, password=Password)
 
             create_dir(PAYLOAD_PATH)
-            (pid, display_name, bundle_identifier) = open_target_app(device, name_or_bundleid)
+            (session, display_name, bundle_identifier) = open_target_app(device, name_or_bundleid)
             if output_ipa is None:
                 output_ipa = display_name
             output_ipa = re.sub('\.ipa$', '', output_ipa)
-            start_dump(device, pid, output_ipa)
+            start_dump(session, output_ipa)
         except paramiko.ssh_exception.NoValidConnectionsError as e:
             print e
             exit_code = 1


### PR DESCRIPTION
According to Frida documentation

spawn, attach, resume is the correct call order.

Module.ensureInitialized can be used to make sure a module is ready.