### PR TITLE
fix: Exception: key cannot be used for signing

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -331,7 +331,12 @@ if __name__ == '__main__':
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(Host, port=Port, username=User, password=Password, key_filename=KeyFileName)
+            
+            # fix: Exception: key cannot be used for signing
+            if KeyFileName:
+                ssh.connect(Host, port=Port, username=User, password=Password, key_filename=KeyFileName)
+            else:
+                ssh.connect(Host, port=Port, username=User, password=Password, key_filename=KeyFileName, look_for_keys=False, allow_agent=False)
 
             create_dir(PAYLOAD_PATH)
             (session, display_name, bundle_identifier) = open_target_app(device, name_or_bundleid)


### PR DESCRIPTION
Fix exception in case of not specified key file, but paramiko tries to use default one.

Exception: key cannot be used for signing
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/paramiko/transport.py", line 2109, in run
    handler(self.auth_handler, m)
  File "/usr/lib/python3/dist-packages/paramiko/auth_handler.py", line 298, in _parse_service_accept
    sig = self.private_key.sign_ssh_data(blob)
  File "/usr/lib/python3/dist-packages/paramiko/agent.py", line 418, in sign_ssh_data
    raise SSHException("key cannot be used for signing")
paramiko.ssh_exception.SSHException: key cannot be used for signing
